### PR TITLE
feat: macOS SD 安装脚本 (install_mac.sh)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ EdgeTX/OpenTX 遥控器脚本，用于 F3K（手抛滑翔机）和 F5J（电动�
 
 ### 安装和构建
 - `install.bat [盘符:]` - 将脚本安装到遥控器SD卡（Windows）
+- `./install_mac.sh [/Volumes/SD名]` - 将脚本安装到遥控器SD卡（macOS，挂载根目录下需有或自动创建 `SCRIPTS`）
 - `build_sound_dll.bat` - 构建 Windows 声音库用于测试
 - `build_sound_so.sh` - 构建 Linux 声音库用于测试
 

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -e
+
+# Mirrors install.bat: copy script/{TELEMETRY,LAOZHU,emutest,test,CompileFiles.lua} to SD/SCRIPTS/
+export COPYFILE_DISABLE=1
+export COPY_EXTENDED_ATTRIBUTES_DISABLE=1
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_SRC="$ROOT/script"
+
+if [[ ! -d "$SCRIPT_SRC" ]]; then
+  echo "install_mac.sh: missing directory: $SCRIPT_SRC" >&2
+  exit 1
+fi
+
+find "$SCRIPT_SRC" -name '*.luac' -delete
+
+DIRS=(TELEMETRY LAOZHU emutest test)
+FILES=(CompileFiles.lua)
+
+if [[ -n "${1:-}" ]]; then
+  DEST_ROOT="$1"
+else
+  echo 'input the disk to install, such as "/Volumes/EDGE"'
+  read -r DEST_ROOT
+fi
+
+DEST_ROOT="${DEST_ROOT%/}"
+
+if [[ -z "$DEST_ROOT" ]]; then
+  exit 1
+fi
+
+if [[ "$(basename "$DEST_ROOT")" == SCRIPTS ]]; then
+  DEST_ROOT="$(dirname "$DEST_ROOT")"
+fi
+
+if [[ ! -d "$DEST_ROOT" ]]; then
+  echo "install_mac.sh: SD root does not exist: $DEST_ROOT" >&2
+  exit 1
+fi
+
+TARGET="$DEST_ROOT/SCRIPTS"
+mkdir -p "$TARGET"
+
+for d in "${DIRS[@]}"; do
+  if [[ ! -d "$SCRIPT_SRC/$d" ]]; then
+    echo "install_mac.sh: missing source dir: $SCRIPT_SRC/$d" >&2
+    exit 1
+  fi
+  mkdir -p "$TARGET/$d"
+  rsync -av --no-specials --no-devices "$SCRIPT_SRC/$d/" "$TARGET/$d/"
+done
+
+for f in "${FILES[@]}"; do
+  cp -vf "$SCRIPT_SRC/$f" "$TARGET/"
+done
+
+printf '%s\n' 'not init' > "$TARGET/lzinstall.flag"
+echo "-> $TARGET/lzinstall.flag"
+
+echo "installed to $TARGET"


### PR DESCRIPTION
## 摘要
- 新增 `install_mac.sh`，在 macOS 上将 `script/` 下 TELEMETRY、LAOZHU、emutest、test 及 `CompileFiles.lua` 安装到 SD 卡 `SCRIPTS/`，并与 `install.bat` 行为对齐（清除 .luac、写入 `lzinstall.flag`）。
- `CLAUDE.md` 补充 macOS 安装命令说明。

## 测试
- [ ] 在真实挂载的 EdgeTX SD 卷上手动跑一次 `./install_mac.sh "/Volumes/…"`。

Made with [Cursor](https://cursor.com)