### PR TITLE
TextEdit 黑白屏测宽分流；utO 顶层加载 LoadModule

### DIFF
--- a/SCRIPTS/TELEMETRY/common/TextEdit.lua
+++ b/SCRIPTS/TELEMETRY/common/TextEdit.lua
@@ -76,31 +76,49 @@ function TEsetText(textEdit, str)
     textEdit.str = str
 end
 
--- 与 TextEditO 一致：RIGHT 时从右向左接龙，锚点为 x - width。
-local function drawTextAdvanceX(x, y, text, flags)
-    lcd.drawText(x, y, text, flags)
-    local w = select(1, lcd.sizeText(text, flags))
-    if flags % (2 * RIGHT) >= RIGHT then
-        return x - w
-    end
-    return x + w
-end
+-- 加载期二选一：彩屏 sizeText；黑白屏原 getLastLeftPos 三连 drawText（与 TextEditO 一致）。
 
-function TEdraw(textEdit, x, y, invers, option)
+local function TEdraw_color(textEdit, x, y, invers, option)
     if textEdit.focusState == 2 then
+        local function adv(ax, text, flags)
+            lcd.drawText(ax, y, text, flags)
+            local w = select(1, lcd.sizeText(text, flags))
+            if flags % (2 * RIGHT) >= RIGHT then
+                return ax - w
+            end
+            return ax + w
+        end
         if invers then
-            local x2 = drawTextAdvanceX(x, y, textEdit.tailStr, option - INVERS)
-            local x3 = drawTextAdvanceX(x2, y, string.char(textEdit.modiChar), option)
-            drawTextAdvanceX(x3, y, textEdit.headStr, option - INVERS)
+            local x2 = adv(x, textEdit.tailStr, option - INVERS)
+            local x3 = adv(x2, string.char(textEdit.modiChar), option)
+            adv(x3, textEdit.headStr, option - INVERS)
         else
-            local x2 = drawTextAdvanceX(x, y, textEdit.tailStr, option)
-            local x3 = drawTextAdvanceX(x2, y, string.char(textEdit.modiChar), option)
-            drawTextAdvanceX(x3, y, textEdit.headStr, option)
+            local x2 = adv(x, textEdit.tailStr, option)
+            local x3 = adv(x2, string.char(textEdit.modiChar), option)
+            adv(x3, textEdit.headStr, option)
         end
     elseif textEdit.focusState == 1 or textEdit.focusState == 0 then
         lcd.drawText(x, y, textEdit.str, option)
     end
 end
+
+local function TEdraw_bw(textEdit, x, y, invers, option)
+    if textEdit.focusState == 2 then
+        if invers then
+            lcd.drawText(x, y, textEdit.tailStr, option - INVERS)
+            lcd.drawText(lcd.getLastLeftPos(), y, string.char(textEdit.modiChar), option)
+            lcd.drawText(lcd.getLastLeftPos(), y, textEdit.headStr, option - INVERS)
+        else
+            lcd.drawText(x, y, textEdit.tailStr, option)
+            lcd.drawText(lcd.getLastLeftPos(), y, string.char(textEdit.modiChar), option)
+            lcd.drawText(lcd.getLastLeftPos(), y, textEdit.headStr, option)
+        end
+    elseif textEdit.focusState == 1 or textEdit.focusState == 0 then
+        lcd.drawText(x, y, textEdit.str, option)
+    end
+end
+
+TEdraw = type(lcd.sizeText) == "function" and TEdraw_color or TEdraw_bw
 
 function TEsetOnChange(textEdit, onChange)
     textEdit.onChange = onChange

--- a/SCRIPTS/TELEMETRY/common/TextEditO.lua
+++ b/SCRIPTS/TELEMETRY/common/TextEditO.lua
@@ -80,33 +80,51 @@ function TextEdit:setText(str)
     self.str = str
 end
 
--- 统一用 sizeText 推算下一段起点。控件以 SMLSIZE+RIGHT 调用时，多段 drawText 从右向左接龙，
--- 下一段锚点应为 x - width（与 getLastLeftPos 一致）；左对齐时为 x + width。
-local function drawTextAdvanceX(x, y, text, flags)
-    lcd.drawText(x, y, text, flags)
-    local w = select(1, lcd.sizeText(text, flags))
-    if flags % (2 * RIGHT) >= RIGHT then
-        return x - w
-    end
-    return x + w
-end
+-- 加载期二选一：彩屏 sizeText 推算接龙锚点；黑白屏无 sizeText，用原 getLastLeftPos 三连 drawText。
 
-function TextEdit:draw(x, y, invers, option1)
+local function draw_color(self, x, y, invers, option1)
     local option = self:getTextOption(invers, option1)
     if self.focusState == 2 then
+        local function adv(ax, text, flags)
+            lcd.drawText(ax, y, text, flags)
+            local w = select(1, lcd.sizeText(text, flags))
+            if flags % (2 * RIGHT) >= RIGHT then
+                return ax - w
+            end
+            return ax + w
+        end
         if invers then
-            local x2 = drawTextAdvanceX(x, y, self.tailStr, option - INVERS)
-            local x3 = drawTextAdvanceX(x2, y, string.char(self.modiChar), option)
-            drawTextAdvanceX(x3, y, self.headStr, option - INVERS)
+            local x2 = adv(x, self.tailStr, option - INVERS)
+            local x3 = adv(x2, string.char(self.modiChar), option)
+            adv(x3, self.headStr, option - INVERS)
         else
-            local x2 = drawTextAdvanceX(x, y, self.tailStr, option)
-            local x3 = drawTextAdvanceX(x2, y, string.char(self.modiChar), option)
-            drawTextAdvanceX(x3, y, self.headStr, option)
+            local x2 = adv(x, self.tailStr, option)
+            local x3 = adv(x2, string.char(self.modiChar), option)
+            adv(x3, self.headStr, option)
         end
     elseif self.focusState == 1 or self.focusState == 0 then
         lcd.drawText(x, y, self.str, option)
     end
 end
+
+local function draw_bw(self, x, y, invers, option1)
+    local option = self:getTextOption(invers, option1)
+    if self.focusState == 2 then
+        if invers then
+            lcd.drawText(x, y, self.tailStr, option - INVERS)
+            lcd.drawText(lcd.getLastLeftPos(), y, string.char(self.modiChar), option)
+            lcd.drawText(lcd.getLastLeftPos(), y, self.headStr, option - INVERS)
+        else
+            lcd.drawText(x, y, self.tailStr, option)
+            lcd.drawText(lcd.getLastLeftPos(), y, string.char(self.modiChar), option)
+            lcd.drawText(lcd.getLastLeftPos(), y, self.headStr, option)
+        end
+    elseif self.focusState == 1 or self.focusState == 0 then
+        lcd.drawText(x, y, self.str, option)
+    end
+end
+
+TextEdit.draw = type(lcd.sizeText) == "function" and draw_color or draw_bw
 
 function TextEdit:setOnChange(onChange)
     self.onChange = onChange

--- a/SCRIPTS/TELEMETRY/utO.lua
+++ b/SCRIPTS/TELEMETRY/utO.lua
@@ -1,4 +1,6 @@
 gSDCardDir = "/"
+local fun, err = loadScript(gSDCardDir .. "SCRIPTS/TELEMETRY/common/LoadModule.lua", "bt")
+fun()
 gAssertFlag = "ASSERT FLAG!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 local textEdit = nil
 local button = nil
@@ -130,8 +132,6 @@ end
 
 local function init()
     local c2 = collectgarbage("count")
-    local fun, err = loadScript(gSDCardDir .. "SCRIPTS/TELEMETRY/common/LoadModule.lua", "bt")
-    fun()
     LZ_runModule(gSDCardDir .. "LAOZHU/DBGTools/dbg.lua")
     DBG_init(DBG_OPTS)
     DBG_dbg("begin load")


### PR DESCRIPTION
## 摘要

- **TextEdit / TextEditO**：加载期按是否存在 `lcd.sizeText` 选择彩屏（`sizeText` + 嵌套 `adv`）与黑白屏（三连 `drawText` + `getLastLeftPos`）绘制路径，避免黑白屏调用不存在的 `sizeText`。
- **utO.lua**：在设置 `gSDCardDir` 后立即加载 `LoadModule.lua`，修复顶层 `LZ_runModule` 在 `init` 之前为 nil 导致的报错；`init` 内不再重复加载 LoadModule。

## 验证

- `lua test/test.lua` 通过。
- 建议在黑白模拟器/真机上回归 utO 与 Adjust 中 TextEdit 编辑态接龙。

## 相关文件

- `SCRIPTS/TELEMETRY/common/TextEdit.lua`
- `SCRIPTS/TELEMETRY/common/TextEditO.lua`
- `SCRIPTS/TELEMETRY/utO.lua`

Made with [Cursor](https://cursor.com)